### PR TITLE
Updated the framework version and some packages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"
@@ -51,7 +51,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/FinanceServicesApi.Tests/Dockerfile
+++ b/FinanceServicesApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/FinanceServicesApi.Tests/FinanceServicesApi.Tests.csproj
+++ b/FinanceServicesApi.Tests/FinanceServicesApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -20,11 +20,11 @@
     <PackageReference Include="Hackney.Shared.HousingSearch" Version="0.25.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Bogus" Version="25.0.4" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.6" />
     <PackageReference Include="xunit" Version="2.4.2-pre.12" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.4.2-pre.12" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/FinanceServicesApi/Dockerfile
+++ b/FinanceServicesApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/FinanceServicesApi/FinanceServicesApi.csproj
+++ b/FinanceServicesApi/FinanceServicesApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -52,10 +52,10 @@
     <PackageReference Include="Hackney.Shared.Tenure" Version="0.9.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />

--- a/FinanceServicesApi/Startup.cs
+++ b/FinanceServicesApi/Startup.cs
@@ -65,8 +65,7 @@ namespace FinanceServicesApi
                 {
                     fv.RegisterValidatorsFromAssembly(Assembly.GetExecutingAssembly());
                     fv.LocalizationEnabled = false;
-                })
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+                });
             services.AddApiVersioning(o =>
             {
                 o.DefaultApiVersion = new ApiVersion(1, 0);

--- a/FinanceServicesApi/V1/UseCase/GetTenureInformationByIdUseCase.cs
+++ b/FinanceServicesApi/V1/UseCase/GetTenureInformationByIdUseCase.cs
@@ -19,8 +19,8 @@ namespace FinanceServicesApi.V1.UseCase
         }
         public async Task<TenureInformation> ExecuteAsync(Guid id)
         {
-            if (id == null)
-                throw new Exception("The id shouldn't be empty or null.");
+            if (id == Guid.Empty)
+                throw new Exception("The id shouldn't be empty.");
             return await _gateway.GetById(id).ConfigureAwait(false);
         }
     }

--- a/FinanceServicesApi/build.cmd
+++ b/FinanceServicesApi/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/finance-services-api.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/finance-services-api.zip

--- a/FinanceServicesApi/build.sh
+++ b/FinanceServicesApi/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/finance-services-api.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/finance-services-api.zip

--- a/FinanceServicesApi/serverless.yml
+++ b/FinanceServicesApi/serverless.yml
@@ -1,7 +1,7 @@
 service: finance-services-api
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
   memorySize: 2048
   timeout: 30
   tracing:
@@ -13,7 +13,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/finance-services-api.zip
+  artifact: ./bin/release/net6.0/finance-services-api.zip
 
   plugins:
   - serverless-associate-waf  


### PR DESCRIPTION
# What:
 - An upgrade of the dotnet version from 3.1 to 6.
 - An upgrade of some of the packages that are needed for the newer version to get deployed/run.

# Why:
 - It's a mandatory piece of work due to security as the current (3.1) version is reaching its end of life.
 - Better performance.
 - Newer features & syntax.