### PR TITLE
Remove 2nd Auth (Google Group Auth)

### DIFF
--- a/FinanceServicesApi/FinanceServicesApi.csproj
+++ b/FinanceServicesApi/FinanceServicesApi.csproj
@@ -41,7 +41,6 @@
     <PackageReference Include="Faker.NETCore" Version="1.0.2" />
     <PackageReference Include="FluentValidation" Version="10.3.6" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
-    <PackageReference Include="Hackney.Core.Authorization" Version="1.64.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.JWT" Version="1.64.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />

--- a/FinanceServicesApi/Startup.cs
+++ b/FinanceServicesApi/Startup.cs
@@ -15,9 +15,7 @@ using FinanceServicesApi.V1.UseCase;
 using FinanceServicesApi.V1.UseCase.Interfaces;
 using FinanceServicesApi.Versioning;
 using FluentValidation.AspNetCore;
-using Hackney.Core.Authorization;
 using Hackney.Core.DynamoDb;
-using Hackney.Core.JWT;
 using Hackney.Core.Logging;
 using Hackney.Shared.Asset.Domain;
 using Hackney.Shared.Person;
@@ -133,7 +131,6 @@ namespace FinanceServicesApi
                     c.IncludeXmlComments(xmlPath);
             });
 
-            services.AddTokenFactory();
             ConfigureLogging(services, Configuration);
             services.ConfigureDynamoDB();
             RegisterGateways(services);
@@ -276,7 +273,6 @@ namespace FinanceServicesApi
             });
             app.UseSwagger();
             app.UseRouting();
-            app.UseGoogleGroupAuthorization();
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseEndpoints(endpoints =>
             {

--- a/FinanceServicesApi/serverless.yml
+++ b/FinanceServicesApi/serverless.yml
@@ -34,7 +34,6 @@ functions:
       PERSON_API_URL: ${ssm:/housing-finance/${self:provider.stage}/person-api-url}
       SEARCH_API_URL: ${ssm:/housing-finance/${self:provider.stage}/housing-search-api-short-url}
       HOUSING_SEARCH_API_TOKEN: ${ssm:/housing-finance/${self:provider.stage}/housing-search-api-token}
-      REQUIRED_GOOGL_GROUPS: ${ssm:/housing-finance/${self:provider.stage}/authorization/required-google-groups}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
# What:
 - Removed a Google Group Auth middleware.

# Why:
 - The Hackney APIs are already configured with an external authorizer. So this 2nd layer of auth would very likely create the same error as mentioned in this [PR](https://github.com/LBHackney-IT/account-api/pull/101#issue-1340396432).