### PR TITLE
Remove redundant CODEOWNERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty @LBHackney-IT/mtfh-finance


### PR DESCRIPTION
# What:
 - Removing stale CODEOWNERS file.

# Why:
 - No one within the merged `housing` team is any wiser regarding the code within this repository. Restricting PR reviews to just a subset of the team doesn't exactly make sense when that subset doesn't really own the code.

# Notes:
 - The pipeline failure is related the expired SSH key. Will be addressed after the PR is merged.